### PR TITLE
Patch for supporting config settings in rforth1

### DIFF
--- a/lib/config.fs
+++ b/lib/config.fs
@@ -1,0 +1,21 @@
+python
+class Config(Primitive):
+
+  class ConfigItem(Primitive):
+    section = 'configuration'
+    def output(self, outfd):
+      outfd.write('\tCONFIG %s=%s\n' % self.item)
+
+  def run(self):
+    option, value = compiler.parse_word(), compiler.parse_word()
+    item = self.ConfigItem(option)
+    item.item = (option, value)
+    compiler.enter_object(item)
+    # These next 3 lines ensure the config items are attached to
+    # the parse tree, so that they are always emitted in the assembler
+    compiler.push_init_runtime()
+    compiler.current_object.refers_to(item)
+    compiler.pop_object()
+
+compiler.add_primitive('config', Config)
+;python


### PR DESCRIPTION
Hi Samuel,

I noticed you have open issue 1 relating to config items.  I've been using rforth1 on and off for a few months and wrote this library file to allow me to set configuration settings.

I generally put 'needs lib/config.fs' in my source, followed by a sequence of lines such as:

config FOSC XTPLL_XT
config PLLDIV 1
config CPUDIV OSC1_PLL2
...

This approach works for me, even though there are limits in what can be expressed.  

Michael
